### PR TITLE
feat: add org README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 [![DEVHUB](https://img.shields.io/badge/DEV_HUB-03BE09)](https://neardevhub.org/)
 [![CALENDAR](https://img.shields.io/badge/CALENDAR-F9F502)](https://bit.ly/near-dev-calendar)
-[![SUPPORT](https://img.shields.io/badge/SUPPORT-BE0303)](https://t.me/addlist/VyVjNaP190JlOGMx)
+[![DEV SUPPORT](https://img.shields.io/badge/DEV_SUPPORT-BE0303)](https://t.me/addlist/VyVjNaP190JlOGMx)
 [![NEWSLETTER](https://img.shields.io/badge/NEWSLETTER-0087E5)](https://newsletter.neardevhub.org/)
 [![FEEDBACK](https://img.shields.io/badge/FEEDBACK-purple)](https://github.com/near/DX/issues/new?assignees=&labels=enhancement&projects=&template=%F0%9F%A4%94-general-feedback.md&title=%5BFEEDBACK%5D)
 
@@ -34,9 +34,9 @@
 
 ---
 
-### 🚀 Decentralized Front-End Stack
+### 🚀 Decentralized Frontend Stack
 
-> Create a decentralized front end components with the source code stored on-chain 🤯.
+> Create decentralized frontend components by storing it's source code on the blockchain 🤯.
 
 | Name      | Description | Repo | Latest Release |
 | ----------- | ----------- | --- |--|
@@ -44,7 +44,7 @@
 | near-discovery    | near.org Gateway  |[near/near-discovery](https://github.com/near/near-discovery)| [![Latest Release](https://img.shields.io/github/v/release/near/near-discovery?label=)](https://github.com/near/near-discovery/releases)
 | near.social | near.social Gateway | [NearSocial/viewer](https://github.com/NearSocial/viewer) | ➖
 | near-discovery-components | Core components / primitives for near.org | [near/near-discovery-components](https://github.com/near/near-discovery-components)| ➖
-|**👉 FE EXECUTION ENVIRONMENT**||||
+|**👉 EXECUTION ENVIRONMENT**||||
 | VM   | B.O.S. Virtual Machine  | [nearsocial/VM](https://github.com/NearSocial/VM) |[![Latest Release](https://img.shields.io/github/v/release/nearsocial/vm?label=)](https://github.com/nearsocial/vm/releases)
 | BWE | B.O.S. Web Engine ***(WIP replacement for VM)*** | [near/bos-web-engine](https://github.com/near/bos-web-engine) |➖
 |**👉 DATABASE**||||
@@ -78,6 +78,12 @@
 | mpc-recovery | Create and restore accounts w/ OIDC protocol|[near/mpc-recovery](https://github.com/near/mpc-recovery)|➖
 | iDOS | Decentralized identity, storage, and verification | [idos-network/idos-sdk-js](https://github.com/idos-network/idos-sdk-js)|➖
 
+### 🔌 API
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- | --- |
+| near-api-js | API tool for frontend & backend JS libraries |[near/near-api-js](https://github.com/near/near-api-js)|[![Latest Release](https://img.shields.io/github/v/release/near/near-api-js?label=)](https://github.com/near/near-api-js/releases)
+
 ### 📝 Smart Contracts
 
 | Name      | Description | Repo | Latest Release |
@@ -92,12 +98,6 @@
 | ----------- | ----------- | --- | --- |
 | workspaces-js| Testing sandbox written in JS  |[near/workspaces-js](https://github.com/near/workspaces-js)|[![Latest Release](https://img.shields.io/github/v/release/near/near-workspaces-js?label=)](https://github.com/near/near-workspaces-js/releases)
 | workspaces-rs| Testing sandbox written in Rust |[near/workspaces-rs](https://github.com/near/workspaces-rs)|[![Latest Release](https://img.shields.io/github/v/release/near/near-workspaces-rs?label=)](https://github.com/near/near-workspaces-rs/releases)
-
-### 🔌 API
-
-| Name      | Description | Repo | Latest Release |
-| ----------- | ----------- | --- | --- |
-| near-api-js | API tool for frontend & backend JS libraries |[near/near-api-js](https://github.com/near/near-api-js)|[![Latest Release](https://img.shields.io/github/v/release/near/near-api-js?label=)](https://github.com/near/near-api-js/releases)
 
 ### 🔎 Blockchain Data Indexing
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,109 @@
+# NEAR Protocol Developer Guide
+
+[![DEVHUB](https://img.shields.io/badge/DEV_HUB-03BE09)](https://neardevhub.org/)
+[![CALENDAR](https://img.shields.io/badge/CALENDAR-F9F502)](https://bit.ly/near-dev-calendar)
+[![SUPPORT](https://img.shields.io/badge/SUPPORT-BE0303)](https://t.me/addlist/VyVjNaP190JlOGMx)
+[![NEWSLETTER](https://img.shields.io/badge/NEWSLETTER-0087E5)](https://newsletter.neardevhub.org/)
+[![FEEDBACK](https://img.shields.io/badge/FEEDBACK-purple)](https://github.com/near/DX/issues/new?assignees=&labels=enhancement&projects=&template=%F0%9F%A4%94-general-feedback.md&title=%5BFEEDBACK%5D)
+
+> NEAR is dedicated to providing the best developer experience possible for building an open web. This mission is next to impossible to achieve without feedback and contributions from **people like you**. 🫵
+>
+> **Get involved!** 👉 please select one of the options above or contribute to one of the essential developer repositories listed below 🙏
+>
+
+<img src="https://github.com/near/DX/blob/main/assets/near-overview.png?raw=true" width="900"/>
+
+---
+
+### 📝 Docs
+
+| Website      | Description | Repo |
+| ----------- | ----------- | --- |
+|[docs.near.org](https://docs.near.org) | NEAR Developer Documentation |[near/docs](https://github.com/near/docs)
+|[nomicon.io](https://nomicon.io)| NEAR Protocol Specification Documentation | [near/neps](https://github.com/near/neps)
+|[near-nodes.io](https://near-nodes.io)| NEAR Node Documentation _(Validator, RPC, Archival)_ |[near/node-docs](https://github.com/near/node-docs)
+
+---
+
+### ⛓️ Protocol
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- | --- |
+| nearcore | Reference implementation of NEAR Protocol  |[near/nearcore](https://github.com/near/nearcore)|[![Latest Release](https://img.shields.io/github/v/release/near/nearcore?label=)](https://github.com/near/nearcore/releases)
+| NEPs | NEAR Protocol Specifications and Standards  |[near/neps](https://github.com/near/neps)| ➖
+
+---
+
+### 🚀 Decentralized Front-End Stack
+
+> Create a decentralized front end components with the source code stored on-chain 🤯.
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- |--|
+|**👉 GATEWAY**||||
+| near-discovery    | near.org Gateway  |[near/near-discovery](https://github.com/near/near-discovery)| [![Latest Release](https://img.shields.io/github/v/release/near/near-discovery?label=)](https://github.com/near/near-discovery/releases)
+| near.social | near.social Gateway | [NearSocial/viewer](https://github.com/NearSocial/viewer) | ➖
+| near-discovery-components | Core components / primitives for near.org | [near/near-discovery-components](https://github.com/near/near-discovery-components)| ➖
+|**👉 FE EXECUTION ENVIRONMENT**||||
+| VM   | B.O.S. Virtual Machine  | [nearsocial/VM](https://github.com/NearSocial/VM) |[![Latest Release](https://img.shields.io/github/v/release/nearsocial/vm?label=)](https://github.com/nearsocial/vm/releases)
+| BWE | B.O.S. Web Engine ***(WIP replacement for VM)*** | [near/bos-web-engine](https://github.com/near/bos-web-engine) |➖
+|**👉 DATABASE**||||
+| B.O.S. Database | Smart contract hosting frontend source code & user data | [nearsocial/social-db](https://github.com/NearSocial/social-db)|➖
+
+---
+
+### 🛠️ Dev Tools
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- |--|
+| create-near-app | Easy fullstack dApp deployment tool |[near/create-near-app](https://github.com/near/create-near-app)|[![Latest Release](https://img.shields.io/github/v/release/near/create-near-app?label=)](https://github.com/near/create-near-app/releases)
+| BOS VSCode Ext. | VSCode extension for building B.O.S. components | [near/near-vscode](https://github.com/near/near-vscode) | [![Latest Release](https://img.shields.io/github/v/release/near/near-vscode?label=)](https://github.com/near/near-vscode/releases)
+| BOS Loader | Simplifying multiple component local development |[near/bos-loader](https://github.com/near/bos-loader)|[![Latest Release](https://img.shields.io/github/v/release/near/bos-loader?label=)](https://github.com/near/bos-loader/releases)
+
+### 💻 CLI
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- |--|
+| near-cli | JS based CLI for interacting w/ NEAR | [near/near-cli](https://github.com/near/near-cli)|[![Latest Release](https://img.shields.io/github/v/release/near/near-cli?label=)](https://github.com/near/near-cli/releases)
+| near-cli-rs| Rust based CLI for interacting w/ NEAR | [near/near-cli-rs](https://github.com/near/near-cli-rs)| [![Latest Release](https://img.shields.io/github/v/release/near/near-cli-rs?label=)](https://github.com/near/near-cli-rs/releases)
+| BOS CLI | CLI for simplifying local development on BOS | [bos-cli-rs/bos-cli-rs](https://github.com/bos-cli-rs/bos-cli-rs) | [![Latest Release](https://img.shields.io/github/v/release/bos-cli-rs/bos-cli-rs?label=)](https://github.com/bos-cli-rs/bos-cli-rs/releases)
+
+### 🔑 Wallet / Auth
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- | --- |
+| wallet-selector |Wallet integration tool for NEAR|[near/wallet-selector](https://github.com/near/wallet-selector)|[![Latest Release](https://img.shields.io/github/v/release/near/wallet-selector?label=)](https://github.com/near/wallet-selector/releases)
+| web3-onboard | Wallet integration tool for multichain |[blocknative/web3-onboard](https://github.com/blocknative/web3-onboard)|[![Latest Release](https://img.shields.io/github/v/release/blocknative/web3-onboard?label=)](https://github.com/blocknative/web3-onboard/releases)
+| FastAuth Signer | Authenticate and sign transactions w/ FastAuth |[near/fast-auth-signer](https://github.com/near/fast-auth-signer)|➖
+| mpc-recovery | Create and restore accounts w/ OIDC protocol|[near/mpc-recovery](https://github.com/near/mpc-recovery)|➖
+| iDOS | Decentralized identity, storage, and verification | [idos-network/idos-sdk-js](https://github.com/idos-network/idos-sdk-js)|➖
+
+### 📝 Smart Contracts
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- |---|
+| near-sdk-js|Create smart contracts w/ JavaScript | [near/near-sdk-js](https://github.com/near/near-sdk-js) | [![Latest Release](https://img.shields.io/github/v/release/near/near-sdk-js?label=)](https://github.com/near/near-sdk-js/releases)
+| near-sdk-rs|Create smart contracts w/ Rust | [near/near-sdk-rs](https://github.com/near/near-sdk-rs)| [![Latest Release](https://img.shields.io/github/v/release/near/near-sdk-rs?label=)](https://github.com/near/near-sdk-rs/releases)
+| Keypom | Customizable key creation for NFT/FT drops  |[keypom/keypom](https://github.com/keypom/keypom)|[![Latest Release](https://img.shields.io/github/v/release/keypom/keypom?label=)](https://github.com/keypom/keypom/releases)
+
+### 🧪 Testing
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- | --- |
+| workspaces-js| Testing sandbox written in JS  |[near/workspaces-js](https://github.com/near/workspaces-js)|[![Latest Release](https://img.shields.io/github/v/release/near/near-workspaces-js?label=)](https://github.com/near/near-workspaces-js/releases)
+| workspaces-rs| Testing sandbox written in Rust |[near/workspaces-rs](https://github.com/near/workspaces-rs)|[![Latest Release](https://img.shields.io/github/v/release/near/near-workspaces-rs?label=)](https://github.com/near/near-workspaces-rs/releases)
+
+### 🔌 API
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- | --- |
+| near-api-js | API tool for frontend & backend JS libraries |[near/near-api-js](https://github.com/near/near-api-js)|[![Latest Release](https://img.shields.io/github/v/release/near/near-api-js?label=)](https://github.com/near/near-api-js/releases)
+
+### 🔎 Blockchain Data Indexing
+
+| Name      | Description | Repo | Latest Release |
+| ----------- | ----------- | --- | --- |
+| QueryApi | Build custom indexers and query with GraphQL endpoints|[near/queryapi](https://github.com/near/queryapi)|➖
+| near-lake-indexer | Built on [NEAR Indexer](https://github.com/near/nearcore/tree/master/chain/indexer) that stores JSON in AWS S3 bucket  |[near/near-lake-indexer](https://github.com/near/near-lake-indexer)|[![Latest Release](https://img.shields.io/github/v/release/near/near-lake-indexer?label=)](https://github.com/near/near-lake-indexer/releases)
+| near-lake-framework-rs | Stream blocks from NEAR Lake into your server |[near/near-lake-framework-rs](https://github.com/near/near-lake-framework-rs)|[![Latest Release](https://img.shields.io/github/v/release/near/near-lake-framework-rs?label=)](https://github.com/near/near-lake-framework-rs/releases)
+| near-lake-framework-js | Stream blocks from NEAR Lake into your server |[near/near-lake-framework-js](https://github.com/near/near-lake-framework-js)| ➖


### PR DESCRIPTION
This PR introduces a README for NEAR Protocol's GitHub Org. 

- Its purpose is to guide new and existing NEAR developers to essential repositories for building on and contributing to the platform. If we were to think of the NEAR's developer landscape as an amusement park, this page serves as a map for that park. 🎢 

- A prototype for this content was created last year at [near/dx ](https://github.com/near/dx) and is now migrating to its original intended home after review & feedback from many community members. 

- This page should be an actively maintained "living document" with additions and subtractions based on usefulness and relevancy. 
