### PR TITLE
doc: Add default docs to NEAR Org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at social@near.org. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to NEAR
+
+Thank you for your interest in contributing to the NEAR ecosystem! We welcome contributions from everyone, and we appreciate your help in driving the development activity in our community.
+
+## How to Contribute
+
+To contribute to NEAR, please follow these steps:
+
+1. Fork the repository to your own GitHub account.
+2. Create a new branch for your contribution.
+3. Make your changes and improvements.
+4. Test your changes to ensure they work as expected.
+5. Commit your changes and push them to your forked repository.
+6. Open a pull request (PR) from your forked repository to the main NEAR repository.
+7. Feel free to submit draft PRs to get early feedback and to make sure you are on the right track.
+8. The PR name should follow the template: `<type>: <name>`.  Where `type` is:
+   - `fix` for bug fixes;
+   - `feat` for new features;
+   - `refactor` for changes that reorganize code without adding new content;
+   - `doc` for changes that change documentation or comments;
+   - `test` for changes that introduce new tests;
+   - `chore` for grunt tasks like updating dependencies.
+9. Provide a clear and descriptive title for your PR.
+10. Include a detailed description of the changes you made and why they are valuable.
+11. Wait for the maintainers to review your PR and provide feedback.
+12. Make any necessary updates based on the feedback received.
+13. Once your PR is approved, it will be merged into the main repository.
+
+## Reporting Issues
+
+If you encounter any issues or have suggestions for improvements, please open an issue in the repository's [issue tracker](https://github.com/near/{repository}/issues) (Note: If there are no open issues, you'll see a message indicating this.) Provide as much detail as possible, including steps to reproduce the issue and any relevant code snippets.
+
+## Community Guidelines
+
+We expect all contributors to adhere to our community guidelines, which can be found in the repository's [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file. Please be respectful and inclusive in all interactions within the NEAR community.
+
+## Get in Touch
+
+If you have any questions or need further assistance, feel free to reach out to us on our official communication channels, such as our [Discord](http://near.chat/) or [Telegram](https://t.me/neardev) channels.
+
+We appreciate your contributions and look forward to working with you to build an amazing web3 ecosystem with NEAR!

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,66 @@
+# NEAR Developer Support
+
+Welcome to NEAR Developer Support! We are here to help you with any questions or issues you may have while developing on the NEAR web3 ecosystem.
+
+## Table of Contents
+- [Getting Started](#getting-started)
+- [Documentation](#documentation)
+- [Chat Channels](#chat-channels)
+- [Community Forums](#community-forums)
+- [Bug Reports and Feature Requests](#bug-reports-and-feature-requests)
+- [Customer Support](#customer-support)
+- [Additional Resources](#additional-resources)
+
+## Getting Started
+
+If you are new to NEAR, we recommend starting with the following resources:
+
+- [NEAR Documentation](https://docs.near.org/): Comprehensive documentation covering various aspects of NEAR development.
+- [NEAR Examples](https://github.com/near-examples): A collection of example projects to help you get started quickly.
+
+## Documentation
+
+For detailed information on NEAR's features, APIs, and best practices, please refer to the official documentation:
+
+- [NEAR Documentation](https://docs.near.org/)
+
+## Chat Channels
+
+For real-time support and discussions, join our chat channels:
+
+- [NEAR Discord](http://near.chat/): Join the NEAR Discord server to chat with the NEAR community and get help from fellow developers.
+- [NEAR Telegram](https://t.me/neardev): Join the NEAR Telegram server to chat with the NEAR community and get help from fellow developers.
+
+## Ecosystem Resources
+Engage with the NEAR community and get support through our community forums:
+- [NEAR DevHub](https://near.org/devhub.near/widget/app): NEAR DevHub, a centralized hub for NEAR developers to access tutorials, guides, and resources for building on the NEAR Protocol.
+- [NEAR StackExchange](https://near.stackexchange.com/): Ask and answer questions about NEAR on the NEAR StackExchange platform.
+- [NEAR Website](https://near.org): Collection of projects, tools, and resources built on the NEAR Protocol.
+
+## Bug Reports and Feature Requests
+
+If you encounter any bugs or have ideas for new features, please submit them through the appropriate channels:
+
+- [NEAR GitHub Issues](https://github.com/near/{repository}/issues): Report issues related to NEAR. (Note: If there are no open issues, you'll see a message indicating this.)
+- [NEAR GitHub Discussions](https://github.com/orgs/near/discussions): Discussions related to the NEAR ecosystem.
+
+## Customer Support
+
+For more specific help and direct customer care, consider the following resources:
+
+- [Help Center](https://nearhelp.zendesk.com/): Find articles about popular services and topics.
+- [Resolve an Issue](https://nearhelp.zendesk.com/): Get in touch with our Customer Care Team.
+
+## Additional Resources
+
+Here are some additional resources that you may find helpful:
+
+- [NEAR Blog](https://near.org/blog/): Stay up-to-date with the latest news and updates from the NEAR team.
+- [NEAR Twitter](https://twitter.com/NEARProtocol): Follow NEAR on Twitter for announcements and community updates.
+- [NEAR Reddit](https://www.reddit.com/r/nearprotocol/): Join the NEAR subreddit to connect with the NEAR community, share ideas, and get support from fellow developers.
+- [NEAR Warpcast](https://warpcast.com/~/channel/near): Tune into NEAR's Warpcast channel for live streams and broadcasts.
+- [NEAR Facebook](https://www.facebook.com/NEARProtocol): Follow NEAR on Facebook for updates and community engagement.
+- [NEAR YouTube](https://www.youtube.com/channel/UCuKdIYVN8iE3fv8alyk1aMw): Subscribe to NEAR's YouTube channel for video updates and tutorials.
+- [NEAR WeChat](https://pages.near.org/ecosystem/community/wechat/): Join the NEAR community on WeChat.
+
+If you have any further questions or need assistance, don't hesitate to reach out to us. Happy coding!


### PR DESCRIPTION
Added 3 default files that will propagate to all repos in NEAR Org Repo:
1. [CODE_OF_CONDUCT.md](https://github.com/s-n-park/near-dot-github/blob/sp-add-docs/CODE_OF_CONDUCT.md) - this was copied over from protocol github ([nearcore](https://github.com/near/nearcore/blob/master/CODE_OF_CONDUCT.md)) with small update for email contact.
2. [CONTRIBUTING.md](https://github.com/s-n-park/near-dot-github/blob/sp-add-docs/CONTRIBUTING.md) - this was mainly copied from [near-discovery](https://github.com/near/near-discovery/blob/develop/CONTRIBUTING.md). Notably included links to Discord/Telegram Dev support channels.
3. [SUPPORT.md](https://github.com/s-n-park/near-dot-github/blob/sp-add-docs/SUPPORT.md) - this was net new file, mainly copied a bunch of documentation and near.org website links.

[Documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#supported-file-types) from GitHub on setting up Organization Documents and which ones are supported


Context: While ~94% of NEAR Organization Repos on GitHub have a README file, only 12% have a CONTRIBUTING file
![image](https://github.com/near/.github/assets/146785798/d0a537d5-529b-43ad-a2ef-a73539eedc50)